### PR TITLE
fix: replace local go-proton-api path with remote fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,8 +47,7 @@ require (
 
 replace (
 	github.com/ProtonMail/go-crypto => github.com/ProtonMail/go-crypto v1.1.5-proton
-	// github.com/ProtonMail/go-proton-api => github.com/major0/go-proton-api v0.0.4-proton-cleanup
-	github.com/ProtonMail/go-proton-api => ../go-proton-api.git
+	github.com/ProtonMail/go-proton-api => github.com/major0/go-proton-api v0.0.4-proton-cleanup
 	github.com/ProtonMail/gopenpgp/v2 => github.com/ProtonMail/gopenpgp/v2 v2.8.2-proton
 	github.com/miteshbsjat/textfilekv => github.com/major0/textfilekv v1.1.1-list-keys
 )

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
+github.com/major0/go-proton-api v0.0.4-proton-cleanup h1:Ar0pePIyKmnWmsNHIpky5VtGQAqqsfd26wWzJG3bSY4=
+github.com/major0/go-proton-api v0.0.4-proton-cleanup/go.mod h1:oy8mLH7OSa/wgHMDkMJECBntanLxhuLHp2kYSde1cCk=
 github.com/major0/textfilekv v1.1.1-list-keys h1:0mmMGN2YoiQXNpy5sQCUvah8b6nMvDn+6rEOVHYkDvs=
 github.com/major0/textfilekv v1.1.1-list-keys/go.mod h1:1UnyP8127ohnKlvpKawjMx/vECvSHtCz8MQVttbtv0k=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=


### PR DESCRIPTION
## Summary

- Replaces the local filesystem `replace` directive (`../go-proton-api.git`) with the published remote fork (`github.com/major0/go-proton-api v0.0.4-proton-cleanup`)
- This allows `go install` to work without requiring a local clone of `go-proton-api`

## Test plan

- [x] `go mod tidy` completes without errors
- [x] `go install` builds successfully

Made with [Cursor](https://cursor.com)